### PR TITLE
Adapt for napari 0.4.18

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Image Processing",
 ]
 dependencies = [
-    "napari",
+    "napari>=0.4.13",
     "numpy>=1.20",
     "qtpy",
     "scikit-learn",


### PR DESCRIPTION
Since napari 0.4.18, the plugin couldn't be activated anymore, see https://forum.image.sc/t/issue-activating-ilastik-napari/94433

The problem seems to be the wrapping of the layer list's ReverseProxyModel in PublicOnlyProxy. A true ReverseProxyModel would be compatible with `setSourceModel`, but napari seems to wrap it in a PublicOnlyProxy that is supposed to expose the internals, but doesn't quite manage it in a way that satisfies Qt. I suspect the problem is that `type(layer_model) == PublicOnlyProxy` even though `isinstance(layer_model, ReverseProxyModel) == True`.

Anyway, this way napari also stops complaining about accessing the qt viewer.