### PR TITLE
remove seed

### DIFF
--- a/src/ilastik/napari/plugin.py
+++ b/src/ilastik/napari/plugin.py
@@ -26,6 +26,7 @@ from ilastik.napari.filters import FilterSet
 from ilastik.napari.gui import CheckboxTableDialog, rc_pairs
 
 
+# TODO: scale using dask
 @thread_worker
 def _pixel_classification(image, labels, features):
     feature_map = features.transform(numpy.asarray(image.data))
@@ -167,7 +168,6 @@ class PixelClassificationWidget(QWidget):
         self._probabilities_button = probabilities_button
         self._run_button = run_button
         self._progress_bar = progress_bar
-        self._labels_seed = None
         self._update_widgets()
 
     def _update_widgets(self):
@@ -191,8 +191,6 @@ class PixelClassificationWidget(QWidget):
             )
         )
 
-        self._labels_seed = labels_layer.seed
-
         worker = _pixel_classification(image_layer.data, labels_layer.data, features)
         worker.finished.connect(lambda: self._set_enabled(True))
         worker.returned.connect(self._update_output_layers)
@@ -213,15 +211,10 @@ class PixelClassificationWidget(QWidget):
         try:
             layer = self._viewer.layers[self.SEG_LAYER_PARAMS["name"]]
             layer.data = data
-            layer.seed = self._labels_seed
         except KeyError:
-            layer = self._viewer.add_labels(
-                data, seed=self._labels_seed, **self.SEG_LAYER_PARAMS
-            )
+            layer = self._viewer.add_labels(data, **self.SEG_LAYER_PARAMS)
             layer.color_mode = "AUTO"
             layer.editable = False
-        finally:
-            self._labels_seed = None
 
     def _update_proba_layer(self, proba):
         try:


### PR DESCRIPTION
In the latest version of napari, the napari.layers.Labels object does not have a seed attribute any more. 

This PR removes calls to `.seed`, and the passing of `seed `to `.add_labels`.